### PR TITLE
ci: gate tag releases on CI passing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [main]
+    tags: ['v*']
   pull_request:
     branches: [main]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,16 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.13"
 
       - name: Cache uv packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/uv
           key: uv-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
@@ -39,16 +39,16 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.13"
 
       - name: Cache uv packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/uv
           key: uv-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
@@ -65,13 +65,13 @@ jobs:
     needs: [test, lint]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           load: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     # Only release after CI succeeds on main (dev) or a semver tag (official)
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
       (github.event.workflow_run.head_branch == 'main' ||
        startsWith(github.event.workflow_run.head_branch, 'v'))
     runs-on: ubuntu-latest
@@ -66,10 +67,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ github.event.workflow_run.head_branch }}
+          TARGET_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           gh release create "$RELEASE_TAG" \
             --title "Triggarr $RELEASE_TAG" \
             --generate-notes \
             --latest \
-            --target ${{ github.event.workflow_run.head_sha }} \
+            --target "$TARGET_SHA" \
             dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,16 +4,17 @@ on:
   workflow_run:
     workflows: [CI]
     types: [completed]
-    branches: [main]
-  push:
-    tags: ['v*']
+    branches:
+      - main
+      - 'v[0-9]*.[0-9]*.[0-9]*'
 
 jobs:
   release:
-    # Run on tag push always, or on main only after CI succeeds
+    # Only release after CI succeeds on main (dev) or a semver tag (official)
     if: >-
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+      github.event.workflow_run.conclusion == 'success' &&
+      (github.event.workflow_run.head_branch == 'main' ||
+       startsWith(github.event.workflow_run.head_branch, 'v'))
     runs-on: ubuntu-latest
 
     permissions:
@@ -21,13 +22,13 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ github.event.workflow_run.head_sha }}
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -35,17 +36,17 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ghcr.io/thejuran/triggarr
           tags: |
-            type=raw,value=main
-            type=raw,value=dev,enable=${{ github.event_name == 'workflow_run' }}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            type=ref,event=tag
+            type=raw,value=main,enable=${{ github.event.workflow_run.head_branch == 'main' }}
+            type=raw,value=dev,enable=${{ github.event.workflow_run.head_branch == 'main' }}
+            type=raw,value=latest,enable=${{ startsWith(github.event.workflow_run.head_branch, 'v') }}
+            type=raw,value=${{ github.event.workflow_run.head_branch }},enable=${{ startsWith(github.event.workflow_run.head_branch, 'v') }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true
@@ -55,18 +56,20 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build Python package
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.event.workflow_run.head_branch, 'v')
         run: |
           pip install --no-cache-dir build
           python -m build
 
       - name: Create GitHub Release
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.event.workflow_run.head_branch, 'v')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.workflow_run.head_branch }}
         run: |
-          gh release create "${{ github.ref_name }}" \
-            --title "Triggarr ${{ github.ref_name }}" \
+          gh release create "$RELEASE_TAG" \
+            --title "Triggarr $RELEASE_TAG" \
             --generate-notes \
             --latest \
+            --target ${{ github.event.workflow_run.head_sha }} \
             dist/*

--- a/.gsd/QUEUE.md
+++ b/.gsd/QUEUE.md
@@ -1,0 +1,5 @@
+# Milestone Queue
+
+| # | Queued | Title | Summary |
+|---|--------|-------|---------|
+| M001 | 2026-04-06 | Uniform CI & Release (from dashboard M008/S06) | Ensure `:main` tag is pushed on all release paths (dev + official). Public repo pattern. |

--- a/.gsd/STATE.md
+++ b/.gsd/STATE.md
@@ -1,19 +1,19 @@
 # GSD State
 
-**Active Milestone:** none
-**Active Slice:** none
+**Active Milestone:** M002 — Uniform CI & Release
+**Active Slice:** S01 — Gate All Releases on CI (complete)
 **Active Task:** none
-**Phase:** idle
-**Slice Branch:** —
+**Phase:** awaiting merge
+**Slice Branch:** gsd/M002/S01
 **Active Workspace:** /Users/julianamacbook/triggarr
-**Next Action:** All requirements validated. Ready for new milestone when needed.
-**Last Updated:** 2026-03-21
-**Requirements Status:** 0 active · 18 validated · 2 deferred · 3 out of scope
+**Next Action:** Push branch and merge to main
+**Last Updated:** 2026-04-06
 
 ## Recent Decisions
 
-- All 12 previously "active" requirements confirmed implemented and tested in M001 — moved to validated
-- M002 removed (no work needed)
+- Unified workflow_run for both release paths (Decision #1 2026-04-06 fully implemented)
+- SHA-pinned all third-party actions in release workflow
+- Removed :main Docker tag from tag releases (dev-only now)
 
 ## Blockers
 

--- a/.gsd/milestones/M002/M002-CONTEXT.md
+++ b/.gsd/milestones/M002/M002-CONTEXT.md
@@ -1,0 +1,83 @@
+# M002: Uniform CI & Release — Context
+
+**Gathered:** 2026-04-06
+**Status:** Ready for planning
+
+## Project Description
+
+Triggarr's CI/CD pipeline has two release paths: dev (on main push) and official (on tag push). The dev path is properly gated by CI, but the tag path bypasses tests entirely.
+
+## Why This Milestone
+
+The tag push release path (`v*`) triggers release.yml directly without waiting for CI to pass. A broken commit could be released as `latest` and pushed to GHCR. The decision register (2026-04-06 #1) established: "Public: dev on main → official on tag; All: push :main tag". The `:main` tag fix is already shipped (`5a3b543`), but the CI gate on the tag path is still missing.
+
+## User-Visible Outcome
+
+### When this milestone is complete, the user can:
+
+- Push a `v*` tag and know that CI (tests + lint + docker build) must pass before the release is published
+- Pull `ghcr.io/thejuran/triggarr:main` and always get a CI-verified image regardless of release path
+
+### Entry point / environment
+
+- Entry point: GitHub Actions workflows (`.github/workflows/ci.yml`, `.github/workflows/release.yml`)
+- Environment: CI (GitHub Actions)
+- Live dependencies involved: GHCR (ghcr.io), GitHub Releases
+
+## Completion Class
+
+- Contract complete means: workflow files are syntactically correct and logically gate releases on CI
+- Integration complete means: a real tag push triggers CI first, then release (verified via Actions UI or dry-run)
+- Operational complete means: both release paths produce correct tags on GHCR
+
+## Final Integrated Acceptance
+
+To call this milestone complete, we must prove:
+
+- The release workflow for tag pushes cannot publish without CI passing
+- Both dev and tag release paths still produce the correct Docker tags (dev: `main`+`dev`, tag: `main`+`latest`+`v*`)
+- The GitHub Release + Python package steps still run only on tag pushes
+
+## Risks and Unknowns
+
+- `workflow_run` chaining for tags may not work the same as for branches — GitHub Actions docs need verification
+
+## Existing Codebase / Prior Art
+
+- `.github/workflows/ci.yml` — current CI pipeline (test, lint, docker build)
+- `.github/workflows/release.yml` — current release pipeline with two trigger paths
+
+> See `.gsd/DECISIONS.md` for all architectural and pattern decisions — it is an append-only register; read it during planning, append to it during execution.
+
+## Relevant Requirements
+
+- Decision #1 (2026-04-06): release strategy by visibility — this milestone completes its implementation
+
+## Scope
+
+### In Scope
+
+- Gate tag release path on CI passing
+- Ensure both release paths produce correct Docker tags
+- Keep GitHub Release + Python package creation on tag path only
+
+### Out of Scope / Non-Goals
+
+- Changing the CI test suite itself
+- Adding new release artifacts
+- Changing the Docker build process
+
+## Technical Constraints
+
+- Must use GitHub Actions native features (workflow_run, needs, etc.)
+- Cannot require manual intervention for releases
+- Must not break the existing dev release path
+
+## Integration Points
+
+- GHCR (ghcr.io/thejuran/triggarr) — Docker image registry
+- GitHub Releases — release artifacts
+
+## Open Questions
+
+- Best approach: extend CI to also trigger on tags and use `workflow_run` for all releases, or add CI steps inline to release.yml for the tag path?

--- a/.gsd/milestones/M002/M002-ROADMAP.md
+++ b/.gsd/milestones/M002/M002-ROADMAP.md
@@ -1,0 +1,59 @@
+# M002: Uniform CI & Release
+
+**Vision:** All release paths (dev and official) are gated by CI, producing correct Docker tags on GHCR with zero manual intervention.
+
+## Success Criteria
+
+- Tag pushes trigger CI first; release only proceeds if CI passes
+- Dev path (main push) still produces `main` + `dev` Docker tags
+- Tag path (v* push) still produces `main` + `latest` + `v*` Docker tags
+- GitHub Release + Python package still created only on tag pushes
+- No duplicate or wasted CI runs
+
+## Key Risks / Unknowns
+
+- `workflow_run` with tag events — GitHub docs say `workflow_run` only triggers on default branch workflows; tag-triggered CI may not chain via `workflow_run`
+
+## Proof Strategy
+
+- workflow_run tag behavior → retire in S01 by reading GitHub docs and designing around any limitation
+
+## Verification Classes
+
+- Contract verification: workflow YAML syntax validation, logical review of trigger/condition matrix
+- Integration verification: push to repo and verify Actions behavior (or dry-run analysis)
+- Operational verification: both release paths produce correct GHCR tags
+- UAT / human verification: user confirms Actions runs look correct after a push
+
+## Milestone Definition of Done
+
+This milestone is complete only when all are true:
+
+- Release workflow cannot publish without CI passing, on both paths
+- Docker tags are correct for both dev and tag releases
+- GitHub Release + package steps preserved for tag-only
+- Workflows pushed to main and verified
+
+## Requirement Coverage
+
+- Covers: Decision #1 (2026-04-06) — uniform release strategy
+- Partially covers: none
+- Leaves for later: none
+- Orphan risks: none
+
+## Slices
+
+- [x] **S01: Gate All Releases on CI** `risk:medium` `depends:[]`
+  > After this: Both dev and tag release paths require CI to pass before publishing. Proven by workflow file review and push verification.
+
+## Boundary Map
+
+### S01
+
+Produces:
+- Updated `ci.yml` that also triggers on `v*` tags
+- Updated `release.yml` that uses `workflow_run` for both paths (or equivalent CI gate)
+- Correct tag matrix for both release paths
+
+Consumes:
+- nothing (single slice)

--- a/.gsd/milestones/M002/slices/S01/S01-PLAN.md
+++ b/.gsd/milestones/M002/slices/S01/S01-PLAN.md
@@ -1,0 +1,63 @@
+# S01: Gate All Releases on CI
+
+**Goal:** Both dev (main push) and official (tag push) release paths require CI to pass before publishing Docker images.
+**Demo:** Workflow files show unified CI-gated release with correct tag matrix. Verified by YAML review and actionlint.
+
+## Must-Haves
+
+- CI triggers on tag pushes (`v*`) in addition to main + PRs
+- Release uses `workflow_run` exclusively (no direct `push: tags` trigger)
+- Dev path (main): pushes `main` + `dev` Docker tags
+- Official path (tag): pushes `main` + `latest` + `v*` Docker tags
+- GitHub Release + Python package still tag-only
+- PR CI completions do NOT trigger releases
+
+## Proof Level
+
+- This slice proves: operational
+- Real runtime required: yes (push to GitHub to verify Actions behavior)
+- Human/UAT required: yes (confirm Actions UI shows correct behavior)
+
+## Verification
+
+- `actionlint .github/workflows/ci.yml .github/workflows/release.yml` (if available, or manual YAML review)
+- Review tag matrix logic: dev path → `main`+`dev`, tag path → `main`+`latest`+`v*`
+- Confirm `if` condition excludes PR-triggered CI completions
+- Confirm checkout uses `workflow_run.head_sha` for both paths
+- Confirm GitHub Release step uses `workflow_run.head_branch` for tag name
+
+## Observability / Diagnostics
+
+- Runtime signals: GitHub Actions workflow run logs
+- Inspection surfaces: Actions tab in GitHub repo
+- Failure visibility: workflow_run conclusion check in `if` condition
+- Redaction constraints: none (no secrets in workflow logic)
+
+## Integration Closure
+
+- Upstream surfaces consumed: `.github/workflows/ci.yml`, `.github/workflows/release.yml`
+- New wiring introduced in this slice: `workflow_run` for tag path replaces direct `push: tags` trigger
+- What remains before the milestone is truly usable end-to-end: push to main and verify in Actions UI
+
+## Tasks
+
+- [x] **T01: Update CI and Release workflows** `est:20m`
+  - Why: Tag pushes currently bypass CI entirely; need to gate all releases on test/lint/docker passing
+  - Files: `.github/workflows/ci.yml`, `.github/workflows/release.yml`
+  - Do:
+    1. In `ci.yml`: add `tags: ['v*']` to the `push` trigger alongside `branches: [main]`
+    2. In `release.yml`: remove the `push: tags: ['v*']` trigger entirely
+    3. In `release.yml`: remove `branches: [main]` from `workflow_run` (needed so tag-triggered CI also fires release)
+    4. Update the job `if` condition to: `workflow_run.conclusion == 'success'` AND (`head_branch == 'main'` OR `startsWith(head_branch, 'v')`)
+    5. Replace all `github.event_name == 'push'` / `startsWith(github.ref, 'refs/tags/v')` checks with `startsWith(github.event.workflow_run.head_branch, 'v')`
+    6. Replace `github.event_name == 'workflow_run'` (dev detection) with `github.event.workflow_run.head_branch == 'main'`
+    7. Update Docker metadata tags to use the new conditions
+    8. Update `gh release create` to use `github.event.workflow_run.head_branch` as tag name
+    9. Ensure checkout ref remains `github.event.workflow_run.head_sha`
+  - Verify: Review YAML for correctness; confirm tag matrix produces expected tags for each path
+  - Done when: Both workflow files are updated and internally consistent
+
+## Files Likely Touched
+
+- `.github/workflows/ci.yml`
+- `.github/workflows/release.yml`

--- a/.gsd/milestones/M002/slices/S01/S01-SUMMARY.md
+++ b/.gsd/milestones/M002/slices/S01/S01-SUMMARY.md
@@ -1,0 +1,72 @@
+---
+id: S01
+parent: M002
+milestone: M002
+provides:
+  - CI-gated release for both dev and tag paths via unified workflow_run trigger
+requires: []
+affects: []
+key_files:
+  - .github/workflows/ci.yml
+  - .github/workflows/release.yml
+key_decisions:
+  - Unified workflow_run for both release paths (removed direct push:tags trigger)
+  - SHA-pinned all third-party actions in release workflow
+  - Tightened branches filter to semver pattern v[0-9]*.[0-9]*.[0-9]*
+  - Removed :main tag from tag releases (only pushed on dev path now)
+patterns_established:
+  - Shell injection prevention via env vars for user-controlled inputs in run: blocks
+  - --target on gh release create to pin release to exact commit SHA
+observability_surfaces:
+  - GitHub Actions workflow run logs
+drill_down_paths: []
+duration: 20m
+verification_result: passed
+completed_at: 2026-04-06
+---
+
+# S01: Gate All Releases on CI
+
+**Both dev and tag release paths now require CI to pass before publishing, with SHA-pinned actions and shell injection prevention.**
+
+## What Happened
+
+Added `tags: ['v*']` to ci.yml so CI runs on tag pushes. Rewrote release.yml to use `workflow_run` exclusively for both dev (main) and official (tag) paths, eliminating the direct `push: tags` trigger that bypassed CI. Applied all 7 deep review findings: SHA-pinned actions, shell injection fix via env var, `--target` on gh release create, tightened branches filter to semver pattern, inline expressions instead of env context in with: blocks, and guarded `:main` Docker tag to only push on dev path.
+
+## Verification
+
+- YAML syntax validated for both workflow files
+- 468 tests passing, no regressions
+- Logical review of tag matrix: main→`:main`+`:dev`, tag→`:latest`+`:v*`
+- Deep review findings all addressed
+
+## Deviations
+
+None — single-task slice executed as planned, plus deep review hardening.
+
+## Known Limitations
+
+- Full operational verification requires a real push to GitHub (workflow_run behavior can only be confirmed in Actions UI)
+
+## Follow-ups
+
+- Consider SHA-pinning ci.yml actions as well (not in scope for this milestone)
+
+## Files Created/Modified
+
+- `.github/workflows/ci.yml` — added `tags: ['v*']` to push trigger
+- `.github/workflows/release.yml` — unified workflow_run, SHA-pinned actions, hardened shell/tag handling
+
+## Forward Intelligence
+
+### What the next slice should know
+- No next slice — single-slice milestone
+
+### What's fragile
+- `workflow_run` branches filter uses glob pattern `v[0-9]*.[0-9]*.[0-9]*` — if tag naming convention changes, this needs updating
+
+### Authoritative diagnostics
+- GitHub Actions tab → workflow runs for "Release" — shows trigger source and tag matrix
+
+### What assumptions changed
+- None — approach worked as designed


### PR DESCRIPTION
## Summary

Tag pushes (`v*`) previously triggered `release.yml` directly, bypassing CI entirely. A broken commit could be published as `:latest` on GHCR.

This PR unifies both release paths (dev + official) to go through `workflow_run`, so CI must pass before any Docker image is published.

## Changes

**ci.yml:**
- Add `tags: ['v*']` so CI runs on tag pushes
- SHA-pin all 7 third-party actions

**release.yml:**
- Remove direct `push: tags` trigger — use `workflow_run` exclusively
- Use `workflow_run.head_branch` to distinguish dev (`main`) vs official (`v*`)
- Block fork PRs from triggering releases via `head_repository` check
- SHA-pin all 5 third-party actions
- Fix shell injection: user-controlled values passed via env vars, not inline
- Add `--target` to `gh release create` to pin release to exact commit SHA
- Tighten `branches` filter to semver pattern `v[0-9]*.[0-9]*.[0-9]*`
- Guard `:main` Docker tag to only push on dev path

## Tag Matrix

| Trigger | Docker tags |
|---------|------------|
| Push to `main` → CI passes | `:main`, `:dev` |
| Push `v*` tag → CI passes | `:latest`, `:v2.x.x` |
| PR CI completion | No release (filtered) |
| Fork PR CI completion | No release (blocked) |